### PR TITLE
[나슬기] 앨범페이지 플레이리스트 영역 고정 및 회전 각도 유지

### DIFF
--- a/album.html
+++ b/album.html
@@ -13,33 +13,35 @@
     <div class="album_playlist font-['Nanum Square Round']">
       <!--CD 플레이 영역-->
       <!--TODO: 노래 재생 기능 추가-->
-      <div class="album_player flex h-96 w-96 flex-wrap justify-center">
-        <div class="cd-wrap">
-          <img id="cd_1" class="CD_img h-96 rounded-full" src="assets/images/album/album_img/1stEP.jpg" />
-          <img id="cd_2" class="CD_img hidden h-96 rounded-full" src="assets/images/album/album_img/OMG.jpg" />
-          <img id="cd_3" class="CD_img hidden h-96 rounded-full" src="assets/images/album/album_img/GetUp.webp" />
-          <img id="cd_4" class="CD_img hidden h-96 rounded-full" src="assets/images/album/album_img/HowSweet.webp" />
-          <img
-            id="cd_5"
-            class="CD_img hidden h-96 rounded-full"
-            src="assets/images/album/album_img/Supernatural.webp" />
+      <div class="album_player mt-48 w-96">
+        <div class="cd-rotate-wrap">
+          <div class="cd-wrap mx-auto">
+            <img id="cd_1" class="CD_img h-96 rounded-full" src="assets/images/album/album_img/1stEP.jpg" />
+            <img id="cd_2" class="CD_img hidden h-96 rounded-full" src="assets/images/album/album_img/OMG.jpg" />
+            <img id="cd_3" class="CD_img hidden h-96 rounded-full" src="assets/images/album/album_img/GetUp.webp" />
+            <img id="cd_4" class="CD_img hidden h-96 rounded-full" src="assets/images/album/album_img/HowSweet.webp" />
+            <img
+              id="cd_5"
+              class="CD_img hidden h-96 rounded-full"
+              src="assets/images/album/album_img/Supernatural.webp" />
+          </div>
         </div>
         <!--앨범 이동 btn 영역-->
-        <ul class="album_player_btn mx-16 mt-14 flex items-center justify-center">
+        <ul class="album_player_btn mx-auto mt-14 flex w-72 items-center justify-between">
           <li>
-            <button id="preAlbum" onclick="toPreAlbum()">
-              <img class="h-12 w-12" src="assets/images/albums/previous.png"
-            /></button>
-          </li>
-          <li>
-            <button id="playAlbum" class="album_player_play_btn" onclick="playAlbum()">
-              <img class="mx-10 h-20 w-20" src="assets/images/albums/play-circle.png" />
+            <button id="preAlbum" onclick="changeAlbum('prev')">
+              <img class="h-12 w-12" src="assets/images/albums/previous.png" />
             </button>
           </li>
           <li>
-            <button id="nextAlbum" onclick="toNextAlbum()">
-              <img class="h-12 w-12" src="assets/images/albums/previous-1.png"
-            /></button>
+            <button id="playAlbum" class="album_player_play_btn" onclick="playAlbum()">
+              <img class="h-20 w-20" src="assets/images/albums/play-circle.png" />
+            </button>
+          </li>
+          <li>
+            <button id="nextAlbum" onclick="changeAlbum('next')">
+              <img class="h-12 w-12" src="assets/images/albums/previous-1.png" />
+            </button>
           </li>
         </ul>
       </div>
@@ -53,7 +55,7 @@
               <p>Aug 1, 2022</p>
               <p>05:07 AM</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--## Title 3번째 줄 영수증-->
             <div class="flex justify-between">
               <div class="flex w-24 justify-between">
@@ -62,7 +64,7 @@
               </div>
               <p>LENGTH</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <div class="album_selct">
               <div class="album_selct_btn_01 flex justify-between">
                 <!--TODO: 선택영역 선택시 해당 음악 플레이-->
@@ -98,7 +100,7 @@
                 <p>2:57</p>
               </div>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <div class="album_item_count flex justify-between">
               <p>ITEM COUNT:</p>
               <p>4</p>
@@ -113,7 +115,7 @@
               <p>Jan 2, 2023</p>
               <p>04:11 AM</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--## Title 3번째 줄 영수증-->
             <div class="flex justify-between">
               <div class="flex w-24 justify-between">
@@ -122,7 +124,7 @@
               </div>
               <p>LENGTH</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
 
             <div class="album_selct">
               <div class="album_selct_btn_01 flex justify-between">
@@ -143,7 +145,7 @@
                 <p>3:06</p>
               </div>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--TODO: 앨범 속 음악 총 수, 시간에 따라 변경되야하는데 시간이없으시면 다른 내용으로 바꿔주세용-->
             <div class="album_item_count flex justify-between">
               <p>ITEM COUNT:</p>
@@ -159,7 +161,7 @@
               <p>Jun 21, 2023</p>
               <p>10:06 AM</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--## Title 3번째 줄 영수증-->
             <div class="flex justify-between">
               <div class="flex w-24 justify-between">
@@ -168,7 +170,7 @@
               </div>
               <p>LENGTH</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <div class="album_selct">
               <div class="album_selct_btn_01 flex justify-between">
                 <!--TODO: 선택영역 선택시 해당 음악 플레이-->
@@ -220,7 +222,7 @@
                 <p>2:15</p>
               </div>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--TODO: 앨범 속 음악 총 수, 시간에 따라 변경되야하는데 시간이없으시면 다른 내용으로 바꿔주세용-->
             <div class="album_item_count flex justify-between">
               <p>ITEM COUNT:</p>
@@ -236,7 +238,7 @@
               <p>May 24, 2024</p>
               <p>05:15 AM</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--## Title 3번째 줄 영수증-->
             <div class="flex justify-between">
               <div class="flex w-24 justify-between">
@@ -245,7 +247,7 @@
               </div>
               <p>LENGTH</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <div class="album_selct">
               <div class="album_selct_btn_01 flex justify-between">
                 <!--TODO: 선택영역 선택시 해당 음악 플레이-->
@@ -281,7 +283,7 @@
                 <p>3:20</p>
               </div>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--TODO: 앨범 속 음악 총 수, 시간에 따라 변경되야하는데 시간이없으시면 다른 내용으로 바꿔주세용-->
             <div class="album_item_count flex justify-between">
               <p>ITEM COUNT:</p>
@@ -297,7 +299,7 @@
               <p>Jul 21, 2026</p>
               <p>04:21 AM</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <!--## Title 3번째 줄 영수증-->
             <div class="flex justify-between">
               <div class="flex w-24 justify-between">
@@ -306,7 +308,7 @@
               </div>
               <p>LENGTH</p>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <div class="album_selct">
               <div class="album_selct_btn_01 flex justify-between">
                 <!--TODO: 선택영역 선택시 해당 음악 플레이-->
@@ -342,7 +344,7 @@
                 <p>2:41</p>
               </div>
             </div>
-            <p>--------------------------------------------------------------------------------------</p>
+            <hr class="my-4 border-dashed border-black" />
             <div class="album_item_count flex justify-between">
               <p>ITEM COUNT:</p>
               <p>4</p>
@@ -353,7 +355,7 @@
             </div>
           </div>
         </div>
-        <p>--------------------------------------------------------------------------------------</p>
+        <hr class="my-4 border-dashed border-black" />
         <div class="album_card flex justify-between">
           <p>CARD:</p>
           <p>XXXX XXXX XXXX 3264</p>
@@ -370,7 +372,7 @@
           <p>LABEL:</p>
           <p>PREVIOUS ADOR</p>
         </div>
-        <p>--------------------------------------------------------------------------------------</p>
+        <hr class="my-4 border-dashed border-black" />
         <a
           class="album_newjeans_playlist_qr_image"
           href="https://www.youtube.com/watch?v=A4S8zl50AdM&list=PL_Cqw69_m_ywY88NJ5SlpuaO_rmpKXO0D">

--- a/assets/css/album.css
+++ b/assets/css/album.css
@@ -3,22 +3,20 @@
   height: auto;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   margin: 0 auto;
 }
 
 /* cd 애니메이션 효과 */
-.cd-wrap > img {
+.cd-rotate-wrap {
   transition: 0.3s linear;
-  transform: rotateY(0);
 }
-.cd-wrap > img.running {
-  animation: musicQ 5s linear infinite;
-  animation-play-state: running;
-}
-.cd-wrap > img.paused {
+.cd-wrap {
   animation: musicQ 5s linear infinite;
   animation-play-state: paused;
+}
+.cd-wrap.running {
+  animation-play-state: running;
 }
 @keyframes musicQ {
   0% {
@@ -51,14 +49,6 @@
   margin: 0 auto 20px;
   width: 112px;
   height: 112px;
-}
-
-.album_player_btn {
-  margin: 36px;
-}
-
-.album_player_play_btn {
-  margin: 0 20px;
 }
 
 /*앨범 영수증 플레이리스트 버튼 호버시 효과*/

--- a/assets/js/album-playlist.js
+++ b/assets/js/album-playlist.js
@@ -24,18 +24,50 @@ function nowAlbumSelect() {
  * cd 재생/정지 애니메이션(Z축 회전)
  */
 function playAlbum() {
-  nowAlbumSelect()
-  if (nowAlbum.classList.contains('running')) {
+  const cdWrap = document.querySelector('.cd-wrap')
+  // nowAlbumSelect()
+  if (cdWrap.classList.contains('running')) {
     //재생중일때, 정지
-    nowAlbum.classList.add('paused')
     playBtn.querySelector('img').src = playImg
-  } else if (!nowAlbum.classList.contains('running')) {
+  } else {
     //재생아닐때, 재생
-    nowAlbum.classList.add('running')
     playBtn.querySelector('img').src = pausedImg
   }
+  cdWrap.classList.toggle('running')
 }
 
+/**
+ * 이전/다음 앨범으로 넘어가는 함수
+ *
+ * @param {string} direction 이전/다음 영상 여부. 값이 없을 경우 첫 번째 영상
+ */
+function changeAlbum(direction) {
+  nowAlbumSelect() //현재 화면에 나오고있는 앨범을 배열에서 선택
+  const cdRotateWrap = document.querySelector('.cd-rotate-wrap')
+  const cdWrap = document.querySelector('.cd-wrap')
+  //재생/정지 초기화
+  if (cdWrap.classList.contains('running')) {
+    cdWrap.classList.remove('running')
+  }
+  //다음 cd로 넘어가는 Y축 회전 애니메이션 시작
+  cdRotateWrap.style.transform = 'rotateY(90deg) scale(1.2)'
+  // TODO: toNextAlbum, toPreAlbum 함수 합치는 작업 중 중단하고 커밋함
+  //애니메이션 동작 시간동안 hidden 적용 딜레이
+  setTimeout(() => {
+    playBtn.querySelector('img').src = playImg
+    nowAlbum.classList.add('hidden')
+    if (direction == 'next') {
+      // 다음 앨범 실행일 경우
+      cdArr[nowAlbumIndex + 1].classList.remove('hidden')
+    } else {
+      // 이전 앨범 실행일 경우
+      cdArr[nowAlbumIndex - 1].classList.remove('hidden')
+    }
+    cdRotateWrap.style.transform = '' //원상복귀
+    nowAlbumSelect() //바뀐 앨범 선택
+    showPlaylist() //영수증 변경
+  }, 300)
+}
 
 /**
  * 다음 버튼 클릭시 다음 앨범으로 넘어가는 함수
@@ -116,12 +148,12 @@ const playlistArr = Array.from(playlistWrap)
  * 현재 cd 이미지에 따라 영수증 플레이리스트 변경
  * (앨범별로 cd이미지의 배열인덱스와 플레이리스트 배열인덱스가 동일)
  */
-function showPlaylist(){
-  for(let i = 0; i < playlistArr.length; i++){
-    if(i == nowAlbumIndex){
-      playlistArr[i].classList.remove("hidden")
-    }else{
-      playlistArr[i].classList.add("hidden")
+function showPlaylist() {
+  for (let i = 0; i < playlistArr.length; i++) {
+    if (i == nowAlbumIndex) {
+      playlistArr[i].classList.remove('hidden')
+    } else {
+      playlistArr[i].classList.add('hidden')
     }
   }
 }


### PR DESCRIPTION
## 설명
1. 앨범영역 고정
    - 플레이 리스트 개수에 따라 영수증 길이가 길어져 정렬이 바뀌고 있음
    - align-items 값과 margin-top 을 이용하여 수정
2. 플레이리스트 중지 후 다음 곡 이동 시 회전 각도 유지
  - CD 이미지들을 한번 더 감싸고, 감싼 요소를 회전시키는 방향으로 해결