### PR TITLE
[한솔] 멤버 카드 내에 TMI 정보 추가

### DIFF
--- a/assets/css/member.css
+++ b/assets/css/member.css
@@ -1,10 +1,10 @@
 /*photo 범위 설정*/
 .photo-grid {
-
   position: relative;
   width: 1240px;
   height: 640px;
   margin: 0 auto;
+  word-break: keep-all;
 }
 
 /* 개별 이미지 컨테이너 */
@@ -13,7 +13,6 @@
   width: 20%;
   height: auto;
 }
-
 
 /* 이미지 스타일 */
 .team-photo img {
@@ -135,10 +134,14 @@
   display: none;
 }
 
-#message-wrap-list>li{
+#message-wrap-list > li {
   animation: showup 0.5s ease-in; /*메세지 추가될때 효과*/
 }
 @keyframes showup {
-  0%{opacity: 0;}
-  100%{opacity: 0.8;}
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0.8;
+  }
 }

--- a/member.html
+++ b/member.html
@@ -45,29 +45,31 @@
         <div class="team-photo-minji-page">
           <div class="team-photo minji-photo1">
             <img class="Team-photo-minji-1" src="assets/images/member/Team-photo-minji_01.png" />
-            <span class="imtext">화창하고 시원한 바람이 부는 신선한 날씨를 좋아해요</span>
+            <span class="imtext">화창하고 시원한 바람이 부는 신선한 날씨를 좋아한다.</span>
           </div>
           <div class="team-photo minji-photo2">
             <img class="team-photo-minji-2" src="assets/images/member/Team-photo-minji_02.png" />
-            <span class="imtext">
-              산책하는 것을 좋아해요. 종종 산책을 하면서 노래를 듣거나 아무 생각 없이 조깅을 해요!
-            </span>
+            <span class="imtext">똑똑하다는 칭찬을 들을 때 가장 기분이 좋다고 한다.</span>
           </div>
           <div class="team-photo minji-photo3">
             <img class="team-photo-minji-3" src="assets/images/member/Team-photo-minji_03.png" />
-            <span class="imtext">버니즈들은 저를 자주 곰돌이라고 불러요</span>
+            <span class="imtext">
+              곰돌이상, 강아지상의 온미녀 느낌이 강하다. 여기서 비롯된 대표적인 별명이 곰아지이다.
+            </span>
           </div>
           <div class="team-photo minji-photo4">
             <img class="team-photo-minji-4" src="assets/images/member/Team-photo-minji_04.png" />
-            <span class="imtext">차분하고 배려심이 많아 팀 내에서 조화로운 리더 역할을 함</span>
+            <span class="imtext">뉴진스엔 공식적인 팀내 포지션이 없지만 민지가 사실상 리더 역할을 수행한다.</span>
           </div>
           <div class="team-photo minji-photo5">
             <img class="team-photo-minji-5" src="assets/images/member/Team-photo-minji_05.png" />
-            <span class="imtext">다국어 가능 (특히 영어에 능숙), 춤과 노래를 동시에 잘 소화</span>
+            <span class="imtext">
+              좋아하는 동물은 토끼, 강아지, 나비, 곰이며, 모두 닮았다고 들어본 동물들이라고 한다.
+            </span>
           </div>
           <div class="team-photo minji-photo6">
             <img class="team-photo-minji-6" src="assets/images/member/Team-photo-minji_06.png" />
-            <span class="imtext">개구리를 좋아해요. 초록색 옷을 즐겨입어서 개구리가 별명이에요.</span>
+            <span class="imtext">만약 운동선수가 된다면 테니스 선수가 됐을 것이라고 한다.</span>
           </div>
           <div class="team-photo minji-photo7">
             <img class="team-photo-minji-7" src="assets/images/member/Team-photo-minji_07.png" />
@@ -76,7 +78,7 @@
               <br />
               2004년 5월 7일
               <br />
-              리더, 서브보컬
+              ESTJ
             </span>
           </div>
         </div>
@@ -84,27 +86,27 @@
         <div class="team-photo-hanni-page">
           <div class="team-photo hanni-photo1">
             <img class="team-photo-hanni-1" src="assets/images/member/hanni/Team-photo-hanni_01.png" />
-            <span class="imtext">하니 내용</span>
+            <span class="imtext">그룹 내 유일한 외국인 멤버로, 호주와 베트남의 복수국적이다.</span>
           </div>
           <div class="team-photo hanni-photo2">
             <img class="team-photo-hanni-2" src="assets/images/member/hanni/Team-photo-hanni_02.png" />
-            <span class="imtext">하니 내용2</span>
+            <span class="imtext">특기는 어디서든 빨리 잠드는 것.</span>
           </div>
           <div class="team-photo hanni-photo3">
             <img class="team-photo-hanni-3" src="assets/images/member/hanni/Team-photo-hanni_03.png" />
-            <span class="imtext">하니 내용3</span>
+            <span class="imtext">무대에 오르기 전 징크스로 긴장을 덜 하기 위해 반지를 많이 만진다고 말했다.</span>
           </div>
           <div class="team-photo hanni-photo4">
             <img class="team-photo-hanni-4" src="assets/images/member/hanni/Team-photo-hanni_04.png" />
-            <span class="imtext">하니 내용4</span>
+            <span class="imtext">민지와 함께 빵을 사랑한다.</span>
           </div>
           <div class="team-photo hanni-photo5">
             <img class="team-photo-hanni-5" src="assets/images/member/hanni/Team-photo-hanni_05.png" />
-            <span class="imtext">하니 내용5</span>
+            <span class="imtext">우쿨렐레, 기타, 피아노를 연주할 줄 안다.</span>
           </div>
           <div class="team-photo hanni-photo6">
             <img class="team-photo-hanni-6" src="assets/images/member/hanni/Team-photo-hanni_06.png" />
-            <span class="imtext">하니 내용6</span>
+            <span class="imtext">2022년 10월 28일, 데뷔 약 3개월 만에 GUCCI의 글로벌 앰버서더로 발탁되었다.</span>
           </div>
           <div class="team-photo hanni-photo7">
             <img class="team-photo-hanni-7" src="assets/images/member/hanni/Team-photo-hanni_07.png" />
@@ -113,7 +115,7 @@
               <br />
               2004년 5월 7일
               <br />
-              리더, 서브보컬
+              INFP
             </span>
           </div>
         </div>
@@ -121,36 +123,36 @@
         <div class="team-photo-dani-page">
           <div class="team-photo dani-photo1">
             <img class="team-photo-dani-1" src="assets/images/member/dani/Team-photo-dani_01.png" />
-            <span class="imtext">다니 내용</span>
+            <span class="imtext">'다니'라는 애칭으로 불리는 것을 가장 좋아한다고 한다.</span>
           </div>
           <div class="team-photo dani-photo2">
             <img class="team-photo-dani-2" src="assets/images/member/dani/Team-photo-dani_02.png" />
-            <span class="imtext">다니 내용2</span>
+            <span class="imtext">민트초코를 좋아하는 민초단이다. 또한 호불호가 갈리는 하와이안 피자도 좋아한다.</span>
           </div>
           <div class="team-photo dani-photo3">
             <img class="team-photo-dani-3" src="assets/images/member/dani/Team-photo-dani_03.png" />
-            <span class="imtext">다니 내용3</span>
+            <span class="imtext">한백혼혈로, 아버지는 백인계 호주인이고 어머니는 한국인이다.</span>
           </div>
           <div class="team-photo dani-photo4">
             <img class="team-photo-dani-4" src="assets/images/member/dani/Team-photo-dani_04.png" />
-            <span class="imtext">다니 내용4</span>
+            <span class="imtext">성숙하고 청아한 음색이 특징으로, 넓은 보컬 레인지와 톤의 다양성이 큰 장점이다.</span>
           </div>
           <div class="team-photo dani-photo5">
             <img class="team-photo-dani-5" src="assets/images/member/dani/Team-photo-dani_05.png" />
-            <span class="imtext">다니 내용5</span>
+            <span class="imtext">웃을 때와 무표정일 때의 인상이 매우 다른 편이다.</span>
           </div>
           <div class="team-photo dani-photo6">
             <img class="team-photo-dani-6" src="assets/images/member/dani/Team-photo-dani_06.png" />
-            <span class="imtext">다니 내용6</span>
+            <span class="imtext">멤버들이 모두 기피하는 생강 과자를 먹고 맛있다 할 정도로 할머니 입맛이다.</span>
           </div>
           <div class="team-photo dani-photo7">
             <img class="team-photo-dani-7" src="assets/images/member/dani/Team-photo-dani_07.png" />
             <span class="imtext">
-              다니
+              다니엘
               <br />
               2004년 5월 7일
               <br />
-              리더, 서브보컬
+              ENFP
             </span>
           </div>
         </div>
@@ -158,36 +160,36 @@
         <div class="team-photo-haerin-page">
           <div class="team-photo haerin-photo1">
             <img class="team-photo-haerin-1" src="assets/images/member/haerin/Team-photo-haerin_01.png" />
-            <span class="imtext">다니 내용</span>
+            <span class="imtext">가장 좋아하는 과일은 복숭아와 아보카도이다.</span>
           </div>
           <div class="team-photo haerin-photo2">
             <img class="team-photo-haerin-2" src="assets/images/member/haerin/Team-photo-haerin_02.png" />
-            <span class="imtext">다니 내용2</span>
+            <span class="imtext">하와이안 피자를 좋아한다. 생선을 좋아하며, 회 또한 매우 좋아한다.</span>
           </div>
           <div class="team-photo haerin-photo3">
             <img class="team-photo-haerin-3" src="assets/images/member/haerin/Team-photo-haerin_03.png" />
-            <span class="imtext">다니 내용3</span>
+            <span class="imtext">자신과 가장 잘 어울리는 호그와트 기숙사는 래번클로일 것 같다고 한다.</span>
           </div>
           <div class="team-photo haerin-photo4">
             <img class="team-photo-haerin-4" src="assets/images/member/haerin/Team-photo-haerin_04.png" />
-            <span class="imtext">다니 내용4</span>
+            <span class="imtext">본인의 헤어스타일은 앞머리 있는 생머리를 선호한다고 한다.</span>
           </div>
           <div class="team-photo haerin-photo5">
             <img class="team-photo-haerin-5" src="assets/images/member/haerin/Team-photo-haerin_05.png" />
-            <span class="imtext">다니 내용5</span>
+            <span class="imtext">운동선수가 된다면 탁구 선수가 됐을 것이라고 한다.</span>
           </div>
           <div class="team-photo haerin-photo6">
             <img class="team-photo-haerin-6" src="assets/images/member/haerin/Team-photo-haerin_06.png" />
-            <span class="imtext">다니 내용6</span>
+            <span class="imtext">팀에서 유일하게 바삭한 시리얼보다는 눅눅한 시리얼을 더 선호한다.</span>
           </div>
           <div class="team-photo haerin-photo7">
             <img class="team-photo-haerin-7" src="assets/images/member/haerin/Team-photo-haerin_07.png" />
             <span class="imtext">
-              다니
+              해린
               <br />
-              2004년 5월 7일
+              2006년 5월 15일
               <br />
-              리더, 서브보컬
+              INTP
             </span>
           </div>
         </div>
@@ -195,36 +197,44 @@
         <div class="team-photo-hyein-page">
           <div class="team-photo hyein-photo1">
             <img class="team-photo-hyein-1" src="assets/images/member/hyein/Team-photo-hyein_01.png" />
-            <span class="imtext">다니 내용</span>
+            <span class="imtext">NewJeans 데뷔조에는 가장 마지막으로 합류했다.</span>
           </div>
           <div class="team-photo hyein-photo2">
             <img class="team-photo-hyein-2" src="assets/images/member/hyein/Team-photo-hyein_02.png" />
-            <span class="imtext">다니 내용2</span>
+            <span class="imtext">
+              강아지를 좋아한다. 리트리버를 가장 좋아하고 비숑도 자기주장이 강하게 생겨서 맘에 든다고 한다.
+            </span>
           </div>
           <div class="team-photo hyein-photo3">
             <img class="team-photo-hyein-3" src="assets/images/member/hyein/Team-photo-hyein_03.png" />
-            <span class="imtext">다니 내용3</span>
+            <span class="imtext">
+              무서운 걸 싫어하고 겁이 많다. 무서운 영화, 소설은 잘 때 자꾸 떠올라서 잘 못 본다고 한다.
+            </span>
           </div>
           <div class="team-photo hyein-photo4">
             <img class="team-photo-hyein-4" src="assets/images/member/hyein/Team-photo-hyein_04.png" />
-            <span class="imtext">다니 내용4</span>
+            <span class="imtext">
+              단무지가 취향이 아니라 냄새도 못 맡는다고 한다. 김밥 안에 들은 것 정도는 괜찮다고.
+            </span>
           </div>
           <div class="team-photo hyein-photo5">
             <img class="team-photo-hyein-5" src="assets/images/member/hyein/Team-photo-hyein_05.png" />
-            <span class="imtext">다니 내용5</span>
+            <span class="imtext">
+              가장 좋아하는 별명은 '혠이'. 자신의 이름에서 나온 별명이라 더 애정이 가기 때문이라고.
+            </span>
           </div>
           <div class="team-photo hyein-photo6">
             <img class="team-photo-hyein-6" src="assets/images/member/hyein/Team-photo-hyein_06.png" />
-            <span class="imtext">다니 내용6</span>
+            <span class="imtext">고기는 매우 좋아하지만 해산물은 싫어한다.</span>
           </div>
           <div class="team-photo hyein-photo7">
             <img class="team-photo-hyein-7" src="assets/images/member/hyein/Team-photo-hyein_07.png" />
             <span class="imtext">
-              다니
+              혜인
               <br />
-              2004년 5월 7일
+              2008년 4월 21일
               <br />
-              리더, 서브보컬
+              ISFP
             </span>
           </div>
         </div>


### PR DESCRIPTION
- 더미 텍스트로 있던 멤버 카드 내 문구를 수정했습니다.
- 가독성 향상을 위해` word-break: keep-all;` 속성 추가했습니다.
- 맴버별 포지션은 의견이 분분하고 공식적으로도 정하지 않고 모호해서 MBTI 내용으로 변경했습니다.
